### PR TITLE
ci: pull LFS objects in checkout steps

### DIFF
--- a/.github/workflows/quarto-publish.yml
+++ b/.github/workflows/quarto-publish.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          lfs: true
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2

--- a/.github/workflows/validate-benchmark.yml
+++ b/.github/workflows/validate-benchmark.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          lfs: true
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary

Both `validate-benchmark.yml` and `quarto-publish.yml` use `actions/checkout@v4` without `lfs: true`. This leaves LFS-tracked files as pointer text on the runner — the validators that open `*.csv` files then see `version https://git-lfs.github.com/spec/v1` as the first line and fail to parse the expected columns.

This is the missing companion to the `.gitattributes`-based LFS setup that #9 introduced — without `lfs: true`, the LFS infrastructure doesn't actually do its job in CI.

Add `with: lfs: true` to both checkout steps. Two-file, four-line change.

## Test plan

- [x] Validate workflow runs successfully on this PR (note: no LFS-tracked files actually exist in `main` yet — the change is a no-op for now, but unblocks #8 which adds an LFS-tracked benchmark).
- [x] After merge, force-push the LFS-migrated version of #8 and confirm validate + build go green.

## Context

Surfaced while preparing #8 (`nk/idr_covariates`) for review — the LFS migration of that benchmark's CSV files passed validators locally but failed in CI because the runner only saw pointer text.