### PR TITLE
infra: prefer yspec-style YAML data dictionary; accept CSV for legacy

### DIFF
--- a/.github/scripts/validate_benchmark.py
+++ b/.github/scripts/validate_benchmark.py
@@ -12,20 +12,28 @@ def validate_benchmark_structure(benchmark_path):
     """Check that required files exist."""
     errors = []
     warnings = []
-    
+
     required_files = [
         'index.qmd',
         'metadata.yml',
         'data/train.csv',
         'data/test.csv',
-        'data/data-dictionary.csv'
     ]
-    
+
     for file in required_files:
         file_path = benchmark_path / file
         if not file_path.exists():
             errors.append(f"Missing required file: {file}")
-    
+
+    # Data dictionary: prefer yspec-style YAML, but accept CSV for backwards compatibility.
+    yml_dict = benchmark_path / 'data/data-dictionary.yml'
+    csv_dict = benchmark_path / 'data/data-dictionary.csv'
+    if not yml_dict.exists() and not csv_dict.exists():
+        errors.append(
+            "Missing required file: data/data-dictionary.yml "
+            "(or data/data-dictionary.csv for legacy submissions)"
+        )
+
     return errors, warnings
 
 def validate_metadata(metadata_path):

--- a/.github/scripts/validate_data.py
+++ b/.github/scripts/validate_data.py
@@ -6,6 +6,7 @@ Validate benchmark data files.
 import sys
 from pathlib import Path
 import pandas as pd
+import yaml
 
 def validate_csv_file(file_path):
     """Validate a CSV file can be read."""
@@ -28,33 +29,50 @@ def validate_csv_file(file_path):
         return errors, warnings, None
 
 def validate_data_dictionary(dict_path, data_columns):
-    """Validate data dictionary covers all columns."""
+    """Validate data dictionary covers all columns.
+
+    Accepts either a yspec-style YAML (preferred) or a legacy CSV dictionary.
+    """
     errors = []
     warnings = []
-    
+
+    suffix = dict_path.suffix.lower()
     try:
-        dict_df = pd.read_csv(dict_path)
-        
-        required_columns = ['column_name', 'description', 'type']
-        for col in required_columns:
-            if col not in dict_df.columns:
-                errors.append(f"data-dictionary.csv missing required column: {col}")
-        
-        if 'column_name' in dict_df.columns:
+        if suffix in ('.yml', '.yaml'):
+            with open(dict_path) as f:
+                spec = yaml.safe_load(f) or {}
+            # yspec convention: top-level keys are column names, with reserved
+            # keys (e.g. SETUP__) wrapped in trailing __ or single underscores.
+            documented_cols = {
+                k for k in spec.keys()
+                if isinstance(k, str) and not k.endswith('__') and not k.startswith('_')
+            }
+            label = dict_path.name
+        elif suffix == '.csv':
+            dict_df = pd.read_csv(dict_path)
+            required_columns = ['column_name', 'description', 'type']
+            for col in required_columns:
+                if col not in dict_df.columns:
+                    errors.append(f"{dict_path.name} missing required column: {col}")
+            if 'column_name' not in dict_df.columns:
+                return errors, warnings
             documented_cols = set(dict_df['column_name'].tolist())
-            data_cols = set(data_columns)
-            
-            missing = data_cols - documented_cols
-            if missing:
-                errors.append(f"data-dictionary.csv missing columns: {missing}")
-            
-            extra = documented_cols - data_cols
-            if extra:
-                warnings.append(f"data-dictionary.csv has extra columns: {extra}")
-        
+            label = dict_path.name
+        else:
+            errors.append(f"Unsupported data dictionary format: {dict_path.name}")
+            return errors, warnings
+
+        data_cols = set(data_columns)
+        missing = data_cols - documented_cols
+        if missing:
+            errors.append(f"{label} missing columns: {sorted(missing)}")
+        extra = documented_cols - data_cols
+        if extra:
+            warnings.append(f"{label} has extra columns: {sorted(extra)}")
+
     except Exception as e:
         errors.append(f"Failed to validate data dictionary: {str(e)}")
-    
+
     return errors, warnings
 
 def validate_train_test_consistency(train_df, test_df):
@@ -126,9 +144,11 @@ def main():
             all_errors.extend([f"{benchmark_dir.name}: {e}" for e in errors])
             all_warnings.extend([f"{benchmark_dir.name}: {w}" for w in warnings])
             
-            # Validate data dictionary
-            dict_path = data_dir / 'data-dictionary.csv'
-            if dict_path.exists():
+            # Validate data dictionary (prefer YAML, fall back to CSV).
+            yml_path = data_dir / 'data-dictionary.yml'
+            csv_path = data_dir / 'data-dictionary.csv'
+            dict_path = yml_path if yml_path.exists() else (csv_path if csv_path.exists() else None)
+            if dict_path is not None:
                 errors, warnings = validate_data_dictionary(dict_path, train_df.columns)
                 all_errors.extend([f"{benchmark_dir.name}: {e}" for e in errors])
                 all_warnings.extend([f"{benchmark_dir.name}: {w}" for w in warnings])

--- a/BENCHMARK_TEMPLATE.md
+++ b/BENCHMARK_TEMPLATE.md
@@ -11,7 +11,7 @@ benchmarks/<your-dataset-name>/
 ├── data/
 │   ├── train.csv               # Training dataset (required)
 │   ├── test.csv                # Test dataset (required)
-│   └── data-dictionary.csv     # Column descriptions (required)
+│   └── data-dictionary.yml     # Column descriptions, yspec-style YAML (required)
 └── README.md                   # Quick reference (optional, auto-generated)
 ```
 
@@ -154,14 +154,46 @@ license: CC-BY-4.0
 doi: TBD  # Will be assigned upon acceptance
 ```
 
-## data-dictionary.csv Template
+## data-dictionary.yml Template
 
-```csv
-column_name,description,units,type,coding
-ID,Subject identifier,-,integer,1-N
-TIME,Time since first dose,hours,numeric,>=0
-...
+[yspec](https://github.com/metrumresearchgroup/yspec)-style YAML. Top-level
+keys are column names (one per data column); reserved keys ending in `__`
+(e.g. `SETUP__`) are not treated as columns.
+
+```yaml
+SETUP__:
+  description: Brief description of this data dictionary
+  glue:
+    - "{{ short }}"
+
+ID:
+  short: Subject identifier
+  type: integer
+  values: 1 to N
+
+TIME:
+  short: Time since first dose
+  type: numeric
+  unit: hours
+  range: [0, ]
+
+DV:
+  short: Dependent variable (plasma concentration)
+  type: numeric
+  unit: mg/L
+  comment: Observation rows only; dose-event rows have DV missing.
+
+DROPOUT:
+  short: Dropout indicator
+  type: integer
+  values:
+    0: completed
+    1: dropped out
 ```
+
+Legacy `data-dictionary.csv` (with columns `column_name, description, units,
+type, coding`) is still accepted by the validator for backwards compatibility
+but new submissions should use YAML.
 
 ## Tips
 

--- a/submission-guide.qmd
+++ b/submission-guide.qmd
@@ -54,7 +54,7 @@ benchmarks/<dataset-name>/
 ├── data/
 │   ├── train.csv          # Training dataset
 │   ├── test.csv           # Test dataset
-│   └── data-dictionary.csv # Column descriptions
+│   └── data-dictionary.yml # Column descriptions (yspec-style YAML)
 ├── metadata.yml           # Machine-readable metadata
 └── README.md              # Quick reference (generated from index.qmd)
 ```
@@ -80,16 +80,48 @@ Your main documentation file must include the following sections:
 - `test.csv`: Test dataset
 - Both files must use the same column structure
 
-#### 3. `data-dictionary.csv`
+#### 3. `data-dictionary.yml`
 
-A CSV file describing each column with the following structure:
+A [yspec](https://github.com/metrumresearchgroup/yspec)-style YAML
+schema documenting each column. Top-level keys are column names (one
+key per column in `train.csv`/`test.csv`); reserved keys ending in `__`
+(e.g. `SETUP__`) are not treated as columns.
 
-| column_name | description | units | type | coding |
-|-------------|-------------|-------|------|--------|
-| ID | Subject identifier | - | integer | - |
-| TIME | Time since first dose | hours | numeric | - |
-| DV | Dependent variable (concentration) | mg/L | numeric | - |
-| ... | ... | ... | ... | ... |
+```yaml
+SETUP__:
+  description: Brief description of this data dictionary
+  glue:
+    - "{{ short }}"
+
+ID:
+  short: Subject identifier
+  type: integer
+  values: 1 to N
+
+TIME:
+  short: Time since first dose
+  type: numeric
+  unit: hours
+  range: [0, ]
+
+DV:
+  short: Dependent variable (plasma concentration)
+  type: numeric
+  unit: mg/L
+  comment: Observation rows only; dose-event rows have DV missing.
+
+DROPOUT:
+  short: Dropout indicator
+  type: integer
+  values:
+    0: completed
+    1: dropped out
+```
+
+Legacy `data-dictionary.csv` files (with columns
+`column_name, description, units, type, coding`) are still accepted by
+the validator for backwards compatibility with earlier submissions, but
+new submissions should use the YAML form.
 
 #### 4. `metadata.yml`
 
@@ -202,7 +234,7 @@ benchmarks/<your-dataset-name>/
 └── data/
     ├── train.csv
     ├── test.csv
-    └── data-dictionary.csv
+    └── data-dictionary.yml
 ```
 
 ### 6. Validate Locally


### PR DESCRIPTION
## Summary

Replace the `data-dictionary.csv` requirement with a preference for [yspec](https://github.com/metrumresearchgroup/yspec)-style `data-dictionary.yml`, per sven/victoria's discussion thread on #8.

- **`validate_benchmark.py`** — accepts either `data-dictionary.yml` or `data-dictionary.csv`. At least one must exist.
- **`validate_data.py`** — `validate_data_dictionary` dispatches by extension. YAML branch treats top-level keys (excluding reserved `*__` keys like `SETUP__`) as documented columns and checks coverage against the data files. CSV branch is unchanged.
- **`submission-guide.qmd`** + **`BENCHMARK_TEMPLATE.md`** — show the YAML form as the recommended path with an example block. CSV is still accepted for legacy submissions.

Backward-compatible: `benchmarks/example-pk-model-selection/` still passes validation with its existing `data-dictionary.csv`.

## Test plan

- [ ] Validators pass on the example benchmark (legacy CSV form) — verified locally.
- [ ] Validators pass on a benchmark using the new YAML form — covered by #8 once this lands.
- [ ] CI workflows on this PR pass (no LFS-tracked data files in the diff, so independent of #11).

## Context

Surfaced while preparing #8. The original `data-dictionary.csv` schema couldn't naturally express nested structure (value-to-label decode tables, per-column type/unit/range), and the discussion thread on #8 converged on a yspec-style YAML format. This PR lands the validator + docs change so #8 can drop its CSV in favour of the new YAML.