### PR TITLE
docs: add scope document and complete YAML data dictionary migration

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,86 +1,108 @@
 # Benchmark Submission
 
+## Submission Track
+
+Which goal does this submission target? (check one)
+
+- [ ] **Goal 1 — Generic Benchmark** (teaching case, agentic dataset, unit-test style, moderate novelty)
+- [ ] **Goal 2 — Grand Challenge** (highly realistic, field-level problem, QM publication eligible)
+
+Not sure? See [Scope & Eligibility](https://pmxbenchmarks.github.io/pmx_benchmarks/scope.html).
+
+---
+
 ## Benchmark Information
 
-**Dataset Name:** 
-**Authors:** 
-**Brief Description:** 
+**Dataset Name:**
+**Authors:**
+**Brief Description:**
+
+---
+
+## Motivation *(required for all submissions)*
+
+> Why should this dataset be added to this repository?
+
+<!-- Your answer here -->
+
+> Which existing datasets (in this repo or elsewhere) are most similar?
+
+<!-- Your answer here -->
+
+> How is this submission concretely different enough to warrant inclusion?
+
+<!-- Your answer here -->
+
+---
 
 ## Submission Checklist
 
-Please ensure all items are completed before requesting review:
-
 ### Required Files
 
-- [ ] `benchmarks/<dataset-name>/index.qmd` with all required sections
+- [ ] `benchmarks/<dataset-name>/index.qmd` with all required sections (including Motivation)
 - [ ] `benchmarks/<dataset-name>/data/train.csv`
 - [ ] `benchmarks/<dataset-name>/data/test.csv`
-- [ ] `benchmarks/<dataset-name>/data/data-dictionary.csv`
-- [ ] `benchmarks/<dataset-name>/metadata.yml`
+- [ ] `benchmarks/<dataset-name>/data/data-dictionary.yml` (yspec-style YAML)
+- [ ] `benchmarks/<dataset-name>/metadata.yml` with `goal` field set
 
-### Documentation Requirements
+### Documentation
 
 - [ ] Abstract clearly describes the benchmark
-- [ ] Background and motivation are provided
+- [ ] Motivation section is present (see above)
+- [ ] Background and context are provided
 - [ ] Data generation process is documented (for synthetic data)
-- [ ] All variables are described with units
-- [ ] Associated tasks are clearly defined with evaluation metrics
+- [ ] All variables described with units in the data dictionary
+- [ ] Tasks clearly defined with metrics and output formats
 - [ ] Train/test split rationale is explained
-- [ ] References are included where appropriate
+- [ ] References included where appropriate
 
-### Data Quality Requirements
+### Data Quality
 
-- [ ] Data is realistic (irregular sampling, confounding dropouts, realistic relationships)
-- [ ] Data is longitudinal
 - [ ] Train and test files use consistent column structure
-- [ ] Data dictionary covers all columns in data files
-- [ ] No personally identifiable information (PII) is included
+- [ ] Data dictionary covers all columns
+- [ ] No personally identifiable information (PII) included
+- [ ] Data is longitudinal *(Goal 2 required; Goal 1 typical)*
+- [ ] Realistic sampling, dropouts, and relationships *(Goal 2 required)*
 
 ### Task Requirements
 
-- [ ] At least one task is defined
-- [ ] Tasks reflect real-world drug development decisions
-- [ ] Evaluation metrics are specified
-- [ ] Evaluation will be performed on test set
+- [ ] At least one task defined with `type`, `output_format`, and `metric`
+- [ ] Evaluation performed on the test set
+- [ ] Tasks reflect real or plausible drug-development decisions
 
-### Metadata Requirements
+### Metadata
 
-- [ ] All required metadata fields are completed
+- [ ] All required fields completed
+- [ ] `goal` field set (`generic` or `grand_challenge`)
 - [ ] YAML syntax is valid
 - [ ] Authors and affiliations are accurate
 - [ ] License is specified
 
-### Technical Validation
+### Technical
 
-- [ ] Quarto builds successfully without errors
-- [ ] All links in documentation work correctly
-- [ ] Data files load correctly (no parsing errors)
+- [ ] Quarto builds successfully: `quarto render benchmarks/<dataset-name>/index.qmd`
+- [ ] Validation scripts pass: `python .github/scripts/validate_benchmark.py`
+- [ ] All links in documentation work
 - [ ] File naming follows conventions (lowercase-with-dashes)
+
+---
 
 ## Additional Information
 
-### Data Generation (if synthetic)
-
-<!-- Briefly describe how the synthetic data was generated -->
-
-### Expected Use Cases
-
-<!-- Describe the intended use cases for this benchmark -->
-
-### Related Publications
+### Related Publications or Preprints
 
 <!-- List any related publications or preprints -->
 
-## Reviewer Notes
+### Notes for Reviewers
 
-<!-- Optional: Add any notes or context for reviewers -->
+<!-- Optional: context, known limitations, or open questions -->
 
 ---
 
 ## For Maintainers
 
-- [ ] Technical validation passed (automated checks)
+- [ ] Automated validation passed
 - [ ] Scientific review completed
 - [ ] Documentation quality approved
-- [ ] DOI requested/assigned
-- [ ] Benchmark listing updated
+- [ ] DOI requested / assigned
+- [ ] Benchmark listing updated on website

--- a/BENCHMARK_TEMPLATE.md
+++ b/BENCHMARK_TEMPLATE.md
@@ -33,6 +33,22 @@ date: YYYY-MM-DD
 
 Brief overview of the benchmark (2-3 sentences).
 
+## Motivation
+
+*Required for all submissions. See [Scope & Eligibility](../../scope.qmd) for details.*
+
+**Why should this dataset be added to this repository?**
+
+...
+
+**Which existing datasets (in this repo or elsewhere) are most similar?**
+
+...
+
+**How is this submission concretely different enough to warrant inclusion?**
+
+...
+
 ## Background
 
 Context and motivation for this benchmark.
@@ -59,7 +75,7 @@ Sample size, dosing regimen, sampling schedule, dropout.
 
 ### Variables
 
-Key variables with brief descriptions. Reference data-dictionary.csv.
+Key variables with brief descriptions. Reference data-dictionary.yml.
 
 ### Sample Size
 
@@ -108,6 +124,7 @@ name: your-dataset-name
 title: Your Full Benchmark Title
 version: 1.0.0
 date: 2025-10-16
+goal: generic          # generic | grand_challenge
 authors:
   - name: Your Name
     affiliation: Your Institution
@@ -191,9 +208,7 @@ DROPOUT:
     1: dropped out
 ```
 
-Legacy `data-dictionary.csv` (with columns `column_name, description, units,
-type, coding`) is still accepted by the validator for backwards compatibility
-but new submissions should use YAML.
+New submissions must use yspec-style YAML for the data dictionary.
 
 ## Tips
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,14 +6,14 @@ Thank you for your interest in contributing to the Pharmacometrics Benchmarks In
 
 ### 1. Submit a Benchmark Dataset
 
-The primary way to contribute is by submitting a high-quality benchmark dataset. See our [Submission Guide](https://korsbo.github.io/pmx_benchmarks/submission-guide.html) for detailed instructions.
+The primary way to contribute is by submitting a benchmark dataset. There are two tracks — read the [Scope & Eligibility](https://pmxbenchmarks.github.io/pmx_benchmarks/scope.html) page first.
 
 **Quick steps:**
 
 1. Fork this repository
 2. Create your benchmark in `benchmarks/<your-dataset-name>/`
 3. Follow the [BENCHMARK_TEMPLATE.md](BENCHMARK_TEMPLATE.md)
-4. Submit a Pull Request using the PR template
+4. Submit a Pull Request using the PR template — include a motivation section
 
 ### 2. Improve Documentation
 
@@ -167,9 +167,9 @@ Contributors will be acknowledged in:
 
 ## Questions?
 
-- Check our [FAQ](https://korsbo.github.io/pmx_benchmarks/submission-guide.html)
+- Check our [FAQ](https://pmxbenchmarks.github.io/pmx_benchmarks/submission-guide.html)
 - [Open a discussion](https://github.com/korsbo/pmx_benchmarks/discussions)
-- [Contact us](https://korsbo.github.io/pmx_benchmarks/contact.html)
+- [Contact us](https://pmxbenchmarks.github.io/pmx_benchmarks/contact.html)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ pmx_benchmarks/
 │       ├── data/
 │       │   ├── train.csv
 │       │   ├── test.csv
-│       │   └── data-dictionary.csv
+│       │   └── data-dictionary.yml
 │       └── README.md
 ├── .github/
 │   ├── workflows/          # CI/CD workflows
@@ -91,20 +91,27 @@ pmx_benchmarks/
 └── README.md               # This file
 ```
 
-## 🔍 Benchmark Requirements
+## 🔍 Benchmark Goals
+
+There are two submission tracks — see the [Scope & Eligibility](https://pmxbenchmarks.github.io/pmx_benchmarks/scope.html) page for details.
+
+**Goal 1 — Generic Benchmarks:** Teaching cases, agentic datasets, unit-test style submissions. Moderate novelty bar. Receives a DOI.
+
+**Goal 2 — Grand Challenges:** Highly realistic drug-development scenarios. High novelty bar. Receives a DOI and is eligible for fast-track consideration at Quantitative Medicine.
 
 All benchmarks must:
 
-- ✅ Be **realistic** (irregular sampling, confounding dropouts, realistic relationships)
-- ✅ Be **longitudinal**
-- ✅ Be **well documented** (generative process, realistic scenario)
-- ✅ Have **associated tasks** for drug development decision-making
+- ✅ Be **pharmacometric in nature** (PK, PD, exposure-response, or related)
+- ✅ Be **well documented** (generative process or scenario description, yspec YAML data dictionary)
+- ✅ Have **associated tasks** with defined metrics
 - ✅ Have a **specified train/test split**
+- ✅ Include a **motivation section** (why this dataset, what's similar, what's different)
 
 ## 🤝 Contributing
 
 We welcome contributions! Please see:
 
+- [Scope & Eligibility](https://pmxbenchmarks.github.io/pmx_benchmarks/scope.html)
 - [Submission Guide](https://pmxbenchmarks.github.io/pmx_benchmarks/submission-guide.html)
 - [Pull Request Template](.github/PULL_REQUEST_TEMPLATE.md)
 

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -13,6 +13,8 @@ website:
         href: index.qmd
       - text: "About"
         href: about.qmd
+      - text: "Scope"
+        href: scope.qmd
       - text: "Submission Guide"
         href: submission-guide.qmd
       - text: "Benchmarks"

--- a/benchmarks/example-pk-model-selection/README.md
+++ b/benchmarks/example-pk-model-selection/README.md
@@ -6,13 +6,13 @@ This is an example benchmark dataset. For full documentation, see [index.qmd](in
 
 - **Documentation:** [index.qmd](index.qmd)
 - **Metadata:** [metadata.yml](metadata.yml)
-- **Data Dictionary:** [data/data-dictionary.csv](data/data-dictionary.csv)
+- **Data Dictionary:** [data/data-dictionary.yml](data/data-dictionary.yml)
 
 ## Files
 
 - `data/train.csv` - Training dataset (140 subjects)
 - `data/test.csv` - Test dataset (60 subjects)
-- `data/data-dictionary.csv` - Variable descriptions
+- `data/data-dictionary.yml` - Variable descriptions
 
 ## Citation
 

--- a/benchmarks/example-pk-model-selection/data/data-dictionary.yml
+++ b/benchmarks/example-pk-model-selection/data/data-dictionary.yml
@@ -1,0 +1,73 @@
+SETUP__:
+  description: Data dictionary for the example PK model selection benchmark
+  glue:
+    - "{{ short }}"
+
+ID:
+  short: Subject identifier
+  type: integer
+  values: 1 to 200
+
+TIME:
+  short: Time since first dose
+  type: numeric
+  unit: hours
+  range: [0, ]
+
+AMT:
+  short: Dose amount
+  type: numeric
+  unit: mg
+  values: 0 or 100
+  comment: Non-zero on dose event rows (EVID=1); 0 on observation rows.
+
+DV:
+  short: Dependent variable (plasma concentration)
+  type: numeric
+  unit: mg/L
+  comment: Positive on observation rows (EVID=0); missing on dose event rows.
+
+EVID:
+  short: Event ID
+  type: integer
+  values:
+    0: observation
+    1: dose
+
+CMT:
+  short: Compartment
+  type: integer
+  values:
+    1: gut
+    2: central
+
+MDV:
+  short: Missing dependent variable flag
+  type: integer
+  values:
+    0: not missing
+    1: missing
+
+WT:
+  short: Body weight
+  type: numeric
+  unit: kg
+
+AGE:
+  short: Age
+  type: numeric
+  unit: years
+
+SEX:
+  short: Sex
+  type: integer
+  values:
+    0: Female
+    1: Male
+
+DROPOUT:
+  short: Dropout indicator
+  type: integer
+  values:
+    0: completed
+    1: dropped out

--- a/benchmarks/example-pk-model-selection/index.qmd
+++ b/benchmarks/example-pk-model-selection/index.qmd
@@ -96,7 +96,7 @@ Where $\epsilon_{prop} \sim N(0, 0.01)$ and $\epsilon_{add} \sim N(0, 0.25)$.
 
 ### Variables
 
-See `data/data-dictionary.csv` for complete descriptions. Key variables:
+See `data/data-dictionary.yml` for complete descriptions. Key variables:
 
 - **ID:** Subject identifier (1-200)
 - **TIME:** Time since first dose (hours)
@@ -170,7 +170,9 @@ train = pd.read_csv('data/train.csv')
 test = pd.read_csv('data/test.csv')
 
 # Load data dictionary
-data_dict = pd.read_csv('data/data-dictionary.csv')
+import yaml
+with open('data/data-dictionary.yml') as f:
+    data_dict = yaml.safe_load(f)
 print(data_dict)
 ```
 

--- a/index.qmd
+++ b/index.qmd
@@ -4,28 +4,32 @@ title: "Pharmacometrics Benchmarks"
 
 ## Welcome
 
-This repository is a place where researchers can upload benchmark datasets for pharmacometrics.
+The Pharmacometrics Benchmarks repository is a curated, peer-reviewed collection of benchmark datasets for evaluating and comparing pharmacometric modeling methodologies. Each accepted dataset receives a DOI and is permanently hosted here.
 
-The datasets will mostly be synthetic with some strong demands on how realistic and well crafted they are. Each benchmark PR will essentially constitute a peer reviewed paper with a DOI and the review process will be rigorous.
+## Two Goals
 
-## Core Purpose
+The repository serves two complementary purposes:
 
-A core purpose is to enable the quantification of performance of different modelling methodology in a way that makes it easier to compare different methodology papers with each other. We will also be able to host competitions.
+**Goal 1 — Generic Benchmarks:** A curated collection of pharmacometric datasets for method comparison, teaching, and automated workflows. The bar for novelty is moderate — datasets must be well-motivated but do not need to represent complex real-world scenarios.
+
+**Goal 2 — Grand Challenges:** Highly realistic datasets targeting specific, hard problems in drug development — the kind that arise when you have "lived through the pain of real data". Designed for community competitions and linked to publication in [Quantitative Medicine](https://ascpt.onlinelibrary.wiley.com/journal/21638306).
+
+Read the [Scope & Eligibility](scope.qmd) page to understand which goal fits your dataset.
 
 ## Why Benchmarks Matter
 
 Standardized benchmarks enable:
 
-- **Reproducible comparisons** between different methodological approaches
+- **Reproducible comparisons** between different modeling approaches
 - **Transparent evaluation** of new methods against established baselines
 - **Community-driven standards** for pharmacometric modeling
 - **Competitive innovation** through organized challenges
 
 ## Getting Started
 
-- Learn more [about this initiative](about.qmd)
+- Read [Scope & Eligibility](scope.qmd) — what belongs here and the two submission tracks
 - Browse available [benchmarks](benchmarks.qmd)
-- Read our [submission guide](submission-guide.qmd)
+- Follow the [Submission Guide](submission-guide.qmd) to contribute
 - [Contact us](contact.qmd) to get involved
 
 ## Recent Benchmarks

--- a/scope.qmd
+++ b/scope.qmd
@@ -1,0 +1,109 @@
+---
+title: "Scope & Eligibility"
+---
+
+---
+
+## Purpose
+
+The Pharmacometrics Benschmarks repository maintains a curated, public collection of pharmacometric benchmark datasets to facilitate reproducible performance comparisons across novel modeling methodologies. It is **planned to be** hosted under ISoP and operated by the Benchmarking Datasets Working Group of the AI/ML SIG.
+
+Content is openly accessible to both ISoP members and the broader scientific community.
+
+The goals are to maintain a curated, public repository of generic benchmark datasets to facilitate performance comparisons across pharmacometric approaches and to curate highly realistic datasets for specific pharmacometric problems ("grand challenges") that embody challenges encountered in real-world drug development, to raise awareness for the field's big problems.
+
+---
+
+## Two Goals
+
+All submissions fall under one of the two goals. The goal determines the review track, effort bar, and publication pathway.
+
+### Goal 1 — "Generic" Benchmarks
+
+> *Maintain a curated, public repository of generic benchmark datasets to facilitate performance comparisons across novel pharmacometric methodologies.*
+
+**Intended for:**
+
+- Teaching cases and educational datasets
+- Agentic/automated workflows ("agentic datasets")
+- Unit-test style submissions isolating a single modeling phenomenon
+- Datasets with moderate complexity and limited novelty requirements
+
+**Review:** Minimal structural review. Novelty bar is not high, but must be justified (see [Novelty & Motivation](#novelty-and-motivation)).
+
+**Outcome:** DOI assigned upon acceptance; listed on the website.
+
+
+---
+
+### Goal 2 — Grand Challenges
+
+> *Curate highly realistic datasets for specific pharmacometric problems ("grand challenges") that embody challenges encountered in real-world drug development, to raise awareness for the field's big problems.*
+
+**Intended for:**
+
+- Datasets targeting complex, realistic drug-development scenarios — by submitters who have "lived through the pain of real data"
+- Multi-task benchmarks with clinical relevance
+- Submissions designed for community competitions and rankings
+- Datasets where the problem itself is the contribution (comparable to CASP / protein folding challenges in biology)
+
+**Review:** Editorial triage, then full quality based peer review in addition to structural review. **Intention to be in the future ** eligible for fast-track consideration at Quantitative Medicine.
+
+**Outcome:** DOI assigned; eligible for featured status, benchmark suite inclusion, and QM publication.
+
+---
+
+## Eligibility Criteria
+
+A submission is in scope if it meets all of the following, regardless of goal:
+
+### 1. Pharmacometric in nature
+
+The dataset must be appropriate for pharmacometric modeling — pharmacokinetics, pharmacodynamics, exposure-response, or closely related quantitative clinical pharmacology tasks. Coverage across PK, PD, QSP, and novel data types (imaging, text, omics, all therapeutic modalities) is explicitly welcomed.
+
+### 2. Longitudinal structure
+
+Data will typically include repeated measurements over time. Non-longitudinal modalities (e.g. DXA, PET imaging) may be considered case-by-case with explicit justification of relevance to the field and need to be included in the suite.
+
+### 3. Well-documented
+
+The submission must include:
+
+- A generative process description, realistic scenario description
+- A [yspec-style YAML data dictionary](https://github.com/metrumresearchgroup/yspec) for all variables
+- A train/test split with documented rationale
+
+### 4. Associated tasks
+
+Each dataset should come with pre-defined tasks by the submitter. Ideally, these tasks will reflect real drug-development decisions (model selection, dose optimization, exposure-response characterization, etc.). Similar to the overall requirements on dataset novelty, this can be simpler for generic submissions (e.g. RMSE) and should be strongly motivated by real situations for the "grand challenge" datasets. Each task must have a defined metric and output format. See the [Submission Guide](submission-guide.qmd) for the task schema.
+
+### 5. Novel and motivated {#novelty-and-motivation}
+
+Submissions must include a **"letter to the editor" style motivation** — a dedicated section in the submission that:
+
+- States why this dataset should be added to the repository
+- Lists the most similar existing datasets (in this repository or elsewhere)
+- Explains concretely how this submission is different enough to warrant inclusion
+
+For Goal 1 submissions, one paragraph is sufficient. For Goal 2 submissions, a fuller justification is expected.
+
+Reviewers will use this section to assess novelty. Novelty is inherently subjective; the letter-style format makes the reasoning transparent and auditable.
+
+---
+
+
+## Incentives for Contributors
+
+We want contributing a benchmark to be rewarding in proportion to the effort put in.
+
+**Every accepted submission receives:**
+
+- A DOI, making it citable in the scientific literature. In addition to being a reward for contributors, this also makes benchmarks involving the dataset well documented and comparable across publications.
+- Permanent hosting and a stable URL
+
+**Goal 2 submissions may additionally receive:**
+
+- **Fast-track consideration at QM** (tbd)
+- **ACoP spotlight** — presentation or poster opportunity at the Annual Conference of Pharmacometrics during SIG lunch
+
+---

--- a/submission-guide.qmd
+++ b/submission-guide.qmd
@@ -4,45 +4,69 @@ title: "Submission Guide"
 
 ## Overview
 
-We welcome high-quality benchmark dataset submissions from the pharmacometrics community. Each submission undergoes rigorous peer review and, upon acceptance, becomes a citable publication with a DOI.
+We welcome benchmark dataset submissions from the pharmacometrics community. There are two submission tracks — read the [Scope & Eligibility](scope.qmd) page first to determine which one fits your dataset.
+
+| | Goal 1 — Generic Benchmarks | Goal 2 — Grand Challenges |
+|-|------------------------------|---------------------------|
+| **Intended for** | Teaching cases, agentic datasets, unit-test style submissions | Highly realistic drug-development scenarios, competition-ready |
+| **Novelty bar** | Moderate — must be justified | High — must address a significant field problem |
+| **Review** | Structural + light novelty review | Editorial triage, then full peer review |
+| **Outcome** | DOI, website listing | DOI, website listing, QM fast-track eligibility, featured status |
+
+All submissions must include a **motivation section** — see [§ Motivation](#motivation) below.
+
+---
 
 ## Benchmark Requirements
 
-All benchmark datasets must meet the following criteria:
+### Requirements for All Submissions
 
-### 1. Realism
+#### 1. Pharmacometric in nature
 
-- **Irregular sampling**: Reflect realistic clinical trial sampling schedules
-- **Confounding dropouts**: Include realistic patient dropout patterns
-- **Realistic relationships**: Capture true dose-exposure-response relationships
+The dataset must be appropriate for pharmacometric modeling — pharmacokinetics, pharmacodynamics, exposure-response, or closely related quantitative clinical pharmacology tasks. Novel data types (imaging, text, omics) are explicitly welcomed.
 
-### 2. Longitudinal Structure
-
-- Data must include repeated measurements over time
-- Appropriate for pharmacometric modeling approaches
-
-### 3. Comprehensive Documentation
+#### 2. Well-documented
 
 Your submission must include:
 
-- **Generative process description**: For synthetic data, document how the data was generated
-- **Realistic scenario description**: Explain what real-world situation the dataset represents
-- **Clear data dictionary**: Describe all variables and their units
+- A generative process description (for synthetic data) or a realistic scenario description
+- A [yspec-style YAML data dictionary](https://github.com/metrumresearchgroup/yspec) for all variables
+- A train/test split with documented rationale
 
-### 4. Associated Tasks
+#### 3. Associated tasks
 
-Define specific tasks that reflect real-world decision-making in drug development:
+Define at least one task with a specified evaluation metric and output format. See [§ Task Schema](#task-schema) below. For Goal 1 submissions, simpler tasks (e.g. RMSE on a single endpoint) are appropriate. For Goal 2, tasks should be strongly motivated by real drug-development decisions.
 
-- Model selection challenges
-- Dose optimization
-- Clinical trial simulation validation
-- Exposure-response characterization
+#### 4. Train/test split
 
-### 5. Train/Test Split
+Provide a pre-specified train/test split. Evaluation metrics are computed on the test set. Document the rationale for the split strategy.
 
-- Provide a pre-specified train/test split
-- Evaluation metrics should be computed on the test set
-- Document the rationale for the split strategy
+#### 5. Motivation {#motivation}
+
+Every submission must include a **"letter to the editor" style motivation** — a dedicated section in `index.qmd` with:
+
+- Why this dataset should be added to this repository
+- Which existing datasets (here or elsewhere) are most similar
+- How this submission is concretely different enough to warrant inclusion
+
+For Goal 1, one paragraph is sufficient. For Goal 2, a fuller justification is expected. Reviewers use this section to assess novelty.
+
+---
+
+### Additional Requirements for Goal 2
+
+#### Realism
+
+The dataset must reflect realistic clinical trial conditions:
+
+- **Irregular sampling**: Realistic clinical sampling schedules
+- **Confounding dropouts**: Realistic patient dropout patterns
+- **Realistic relationships**: True dose-exposure-response relationships
+- **Longitudinal structure**: Repeated measurements over time
+
+Non-longitudinal modalities (e.g. DXA, PET imaging) may be considered case-by-case with explicit justification.
+
+---
 
 ## Submission Structure
 
@@ -56,36 +80,33 @@ benchmarks/<dataset-name>/
 │   ├── test.csv           # Test dataset
 │   └── data-dictionary.yml # Column descriptions (yspec-style YAML)
 ├── metadata.yml           # Machine-readable metadata
-└── README.md              # Quick reference (generated from index.qmd)
+└── README.md              # Quick reference (optional)
 ```
 
 ### Required Files
 
 #### 1. `index.qmd`
 
-Your main documentation file must include the following sections:
+Your main documentation file must include:
 
 - **Title and Authors**
-- **Abstract**: Brief overview of the benchmark
-- **Background**: Context and motivation
+- **Abstract**: Brief overview
+- **Motivation**: Why this dataset belongs here (see [§ Motivation](#motivation))
+- **Background**: Context
 - **Data Generation** (for synthetic data): Detailed methodology
 - **Dataset Description**: Variables, sample size, study design
-- **Tasks**: Specific modeling challenges with evaluation criteria
+- **Tasks**: Modeling challenges with evaluation criteria
 - **Train/Test Split**: Description and rationale
 - **References**: Relevant citations
 
 #### 2. Data Files
 
-- `train.csv`: Training dataset
-- `test.csv`: Test dataset
-- Both files must use the same column structure
+- `train.csv` and `test.csv` must use identical column structure
+- Stored via Git LFS (see [§ Large Data Files](#large-data-files))
 
 #### 3. `data-dictionary.yml`
 
-A [yspec](https://github.com/metrumresearchgroup/yspec)-style YAML
-schema documenting each column. Top-level keys are column names (one
-key per column in `train.csv`/`test.csv`); reserved keys ending in `__`
-(e.g. `SETUP__`) are not treated as columns.
+A [yspec](https://github.com/metrumresearchgroup/yspec)-style YAML schema. Top-level keys are column names; reserved keys ending in `__` are not treated as columns.
 
 ```yaml
 SETUP__:
@@ -118,32 +139,25 @@ DROPOUT:
     1: dropped out
 ```
 
-Legacy `data-dictionary.csv` files (with columns
-`column_name, description, units, type, coding`) are still accepted by
-the validator for backwards compatibility with earlier submissions, but
-new submissions should use the YAML form.
+New submissions must use yspec-style YAML for the data dictionary.
 
 #### 4. `metadata.yml`
-
-Machine-readable metadata in YAML format:
 
 ```yaml
 name: dataset-name
 title: Full Dataset Title
 version: 1.0.0
 date: 2025-10-16
+goal: generic          # generic | grand_challenge
 authors:
   - name: Jane Doe
     affiliation: University Example
     email: jane.doe@example.com
-  - name: John Smith
-    affiliation: Pharma Corp
 description: Brief description of the benchmark
 keywords:
   - pharmacokinetics
   - dose-response
-  - longitudinal
-data_type: synthetic
+data_type: synthetic   # synthetic | semi-synthetic | real
 therapeutic_area: oncology
 n_subjects: 250
 n_observations: 2500
@@ -155,102 +169,55 @@ tasks:
     output_format: {type: individual_predictions, columns: [ID, TIME, PRED]}
     metric: rmse
 license: CC-BY-4.0
+doi: TBD
 ```
+
+---
 
 ## Step-by-Step Guide
 
-This guide walks through a complete submission from scratch. If you are comfortable
-with GitHub and git, skip to [Submission Process](#submission-process) below.
-
 ### Prerequisites
 
-Install the following before starting:
-
-1. **A GitHub account** — [Sign up at github.com](https://github.com/join)
+1. **A GitHub account** — [github.com/join](https://github.com/join)
 2. **Git** — [git-scm.com/downloads](https://git-scm.com/downloads)
-   - macOS: `brew install git`
-   - Windows: use the Git for Windows installer
-   - Linux: `sudo apt install git` or `sudo yum install git`
 3. **Git LFS** — [git-lfs.github.com](https://git-lfs.github.com/)
-   - macOS: `brew install git-lfs`
-   - Windows: included in Git for Windows
-   - Linux: `sudo apt install git-lfs`
 4. **Quarto** — [quarto.org/docs/get-started](https://quarto.org/docs/get-started/)
 
 ### 1. Fork the Repository
 
-1. Go to [github.com/PMxBenchmarks/pmx_benchmarks](https://github.com/PMxBenchmarks/pmx_benchmarks)
-2. Click **Fork** (top-right corner)
-3. Select your GitHub account as the destination
-
-You now have your own copy at `github.com/<your-username>/pmx_benchmarks`.
+Go to [github.com/PMxBenchmarks/pmx_benchmarks](https://github.com/PMxBenchmarks/pmx_benchmarks) and click **Fork**.
 
 ### 2. Clone Your Fork
 
 ```bash
 git clone https://github.com/<your-username>/pmx_benchmarks.git
 cd pmx_benchmarks
-```
-
-### 3. Set Up Git LFS
-
-Run once after cloning:
-
-```bash
 git lfs install
 ```
 
-Verify tracking is active:
-
-```bash
-git lfs track
-```
-
-You should see `*.csv`, `*.parquet`, `*.RData`, and other data formats listed.
-
-### 4. Create a Branch
+### 3. Create a Branch
 
 ```bash
 git checkout -b benchmark/<your-dataset-name>
 ```
 
-Example: `git checkout -b benchmark/idr-pkpd-covariate`
-
-### 5. Add Your Benchmark
-
-Create the directory structure:
+### 4. Add Your Benchmark
 
 ```bash
 mkdir -p benchmarks/<your-dataset-name>/data
 ```
 
 Use `BENCHMARK_TEMPLATE.md` and `benchmarks/example-pk-model-selection/` as references.
-Required files:
 
-```
-benchmarks/<your-dataset-name>/
-├── index.qmd
-├── metadata.yml
-└── data/
-    ├── train.csv
-    ├── test.csv
-    └── data-dictionary.yml
-```
-
-### 6. Validate Locally
+### 5. Validate Locally
 
 ```bash
-# Check Quarto renders without errors
 quarto render benchmarks/<your-dataset-name>/index.qmd
-
-# Run validation scripts
 python .github/scripts/validate_benchmark.py
 python .github/scripts/validate_data.py
 ```
 
-Fix any errors before continuing.
-
-### 7. Commit and Push
+### 6. Commit and Push
 
 ```bash
 git add benchmarks/<your-dataset-name>/
@@ -258,49 +225,37 @@ git commit -m "Add <your-dataset-name> benchmark"
 git push origin benchmark/<your-dataset-name>
 ```
 
-### 8. Open a Pull Request
+### 7. Open a Pull Request
 
-1. Go to your fork: `github.com/<your-username>/pmx_benchmarks`
-2. Click **Compare & pull request** (appears after pushing)
-3. Set base repository to `PMxBenchmarks/pmx_benchmarks`, base branch `main`
-4. Fill in the PR template completely
-5. Click **Create pull request**
+Go to your fork on GitHub and click **Compare & pull request**. Set base repository to `PMxBenchmarks/pmx_benchmarks`, base branch `main`. Fill in the PR template completely — in particular the motivation section.
 
-### 9. Respond to Review
+### 8. Respond to Review
 
-Reviewers will comment on your PR. Push updated commits to the **same branch** —
-do not open a new PR. The existing PR updates automatically.
+Push updates to the **same branch**. Do not open a new PR.
 
 ---
 
 ## Large Data Files
 
-All benchmark data files are stored using git-lfs. Run `git lfs install` once after
-cloning and git will automatically handle tracked file types (`*.csv`, `*.parquet`,
-`*.RData`, `*.rds`, `*.sas7bdat`, `*.xpt`).
+All benchmark data files are stored using Git LFS. Run `git lfs install` once after cloning. Git automatically handles tracked types: `*.csv`, `*.parquet`, `*.RData`, `*.rds`, `*.sas7bdat`, `*.xpt`.
 
 ---
 
 ## Task Schema
 
-Each task in `metadata.yml` should declare a `type`, `output_format`, and `metric`. The validator warns when `type` is absent and enforces `output_format` and `metric` only when `type` is provided.
-Three task types are supported:
+Each task in `metadata.yml` must declare a `type`, `output_format`, and `metric`.
 
 ### Regression
-
-Predict a continuous outcome for each row in the test set.
 
 ```yaml
 - name: prediction-accuracy
   type: regression
-  target: DV                    # column in test.csv with ground truth values
+  target: DV
   output_format: {type: individual_predictions, columns: [ID, TIME, PRED]}
-  metric: rmse                  # rmse | mae | nrmse
+  metric: rmse          # rmse | mae | nrmse
 ```
 
 ### Classification
-
-Predict a binary or multi-class outcome.
 
 ```yaml
 # Soft predictions
@@ -318,9 +273,6 @@ Predict a binary or multi-class outcome.
 
 ### Counterfactual
 
-Report aggregate statistics under a hypothetical intervention. Output must be
-aggregates — not individual-level predictions.
-
 ```yaml
 - name: cmax-exceedance-2x-dose
   type: counterfactual
@@ -330,9 +282,7 @@ aggregates — not individual-level predictions.
   metric: quantile_coverage
 ```
 
-The `truth_file` must be deposited in `tasks/` and contain pre-computed ground truth
-from your generative model. Its `estimates` keys must exactly match the names declared
-in `output_format.stats`:
+The `truth_file` contains pre-computed ground truth from your generative model:
 
 ```yaml
 # tasks/cmax_truth.yml
@@ -347,58 +297,10 @@ estimates:
   q90: 118.4
 ```
 
-The other supported counterfactual output type is `probability` (with `threshold` and
-`direction: above|below`; truth file needs a single `p` key).
-
-One metric per task — create separate tasks if you want multiple metrics evaluated.
+One metric per task — create separate tasks for multiple metrics.
 
 ---
 
-## Submission Process
-
-### Step 1: Prepare Your Benchmark
-
-1. Create your benchmark following the structure above
-2. Test that your documentation builds correctly with Quarto
-3. Validate that your data files are properly formatted
-
-### Step 2: Submit a Pull Request
-
-1. Fork this repository
-2. Create a new branch: `git checkout -b benchmark/<your-dataset-name>`
-3. Add your benchmark to `benchmarks/<your-dataset-name>/`
-4. Commit your changes with a clear message
-5. Push to your fork and submit a Pull Request
-
-Use our [Pull Request template](.github/PULL_REQUEST_TEMPLATE.md) which will guide you through the submission checklist.
-
-### Step 3: Peer Review
-
-Your submission will undergo peer review:
-
-- Technical validation (automated checks)
-- Scientific review (expert evaluation)
-- Documentation quality assessment
-
-Reviewers will provide feedback via PR comments. Please address all comments before final acceptance.
-
-### Step 4: Acceptance and Publication
-
-Upon acceptance:
-
-- Your benchmark will be merged into the main repository
-- A DOI will be assigned
-- Your benchmark will appear on the website
-- You can cite it in publications
-
-## Tips for a Successful Submission
-
-- **Start early**: The review process may take several iterations
-- **Be thorough**: Complete documentation speeds up review
-- **Test your data**: Ensure files load correctly and contain expected information
-- **Engage with reviewers**: Respond promptly to feedback
-- **Follow examples**: Look at existing benchmarks for guidance
-
 ## Questions?
 
-If you have questions about the submission process, please [contact us](contact.qmd) or open a discussion on GitHub.
+[Contact us](contact.qmd) or open a discussion on GitHub.


### PR DESCRIPTION
## Summary

- **New page: `scope.qmd`** — defines the two submission goals (Goal 1 Generic
  Benchmarks, Goal 2 Grand Challenges), eligibility criteria, novelty/motivation
  requirements, incentives, governance timeline, and open questions. Added to the
  navbar between About and Submission Guide. 

- **Complete YAML migration** — finishes the work started in #12: all remaining
  `data-dictionary.csv` references removed from docs, templates, and the example
  benchmark; `example-pk-model-selection/data/data-dictionary.yml` created from
  the existing CSV.

- **Two-goal framing applied throughout** — `submission-guide.qmd`,
  `BENCHMARK_TEMPLATE.md`, PR template, `index.qmd`, `README.md`, and
  `CONTRIBUTING.md` updated to reflect Goal 1 vs Goal 2 distinction,
  motivation/letter-to-editor requirement, and `goal` field in `metadata.yml`.